### PR TITLE
Sync Substack posts into the Writing section

### DIFF
--- a/.github/workflows/update-substack.yml
+++ b/.github/workflows/update-substack.yml
@@ -1,0 +1,35 @@
+name: Update Substack posts
+
+on:
+  schedule:
+    # Daily at 13:00 UTC (~6am Pacific)
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-substack
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync posts into index.html
+        run: python3 scripts/update_substack.py
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- index.html; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html
+          git commit -m "Update Substack posts in Writing section"
+          git push

--- a/index.html
+++ b/index.html
@@ -524,6 +524,21 @@
     <section>
       <p class="section-label">Writing</p>
       <ul class="writing-list">
+        <!-- Posts below are synced from Substack by .github/workflows/update-substack.yml. Don't edit by hand. -->
+        <!-- substack:start -->
+        <li>
+          <span class="w-date">2026</span>
+          <a href="https://nolastan.substack.com/p/know-this-place" target="_blank">Know This Place</a>
+        </li>
+        <li>
+          <span class="w-date">2025</span>
+          <a href="https://nolastan.substack.com/p/learning-from-the-past" target="_blank">Learning from the past</a>
+        </li>
+        <li>
+          <span class="w-date">2025</span>
+          <a href="https://nolastan.substack.com/p/nature-in-the-city" target="_blank">Nature in the City</a>
+        </li>
+        <!-- substack:end -->
         <li>
           <span class="w-date">2023</span>
           <a href="https://www.reducemail.org/how-to-fill-a-community-fridge/" target="_blank">How to fill a community fridge</a>

--- a/scripts/update_substack.py
+++ b/scripts/update_substack.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Sync Substack posts into the Writing list in index.html.
+
+Substack serves no CORS headers, so the browser can't fetch the archive
+directly. Instead this runs in CI (see .github/workflows/update-substack.yml)
+and writes the posts straight into the HTML between the marker comments.
+
+Exits non-zero without touching index.html if the fetch fails or returns
+nothing, so a bad API response can never blank out the list.
+"""
+
+import html
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PUBLICATION = "https://nolastan.substack.com"
+INDEX = Path(__file__).resolve().parent.parent / "index.html"
+
+# Posts to keep out of the Writing list, by slug — the trailing part of the
+# post URL (.../p/<slug>). Slugs are stable even when a title is edited.
+EXCLUDED_SLUGS = {
+    "easter-420-earth-day-and-climate",  # Sunset Dunes is Open!
+}
+
+START = "<!-- substack:start -->"
+END = "<!-- substack:end -->"
+
+PAGE_SIZE = 50
+USER_AGENT = "nolastan.github.io-substack-sync"
+INDENT = " " * 8
+
+
+def fetch_posts():
+    """Page through the archive API until it runs out of posts."""
+    posts = []
+    offset = 0
+    while True:
+        url = f"{PUBLICATION}/api/v1/archive?sort=new&limit={PAGE_SIZE}&offset={offset}"
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            page = json.load(response)
+        if not isinstance(page, list):
+            raise ValueError(f"unexpected response at offset {offset}: {page!r}")
+        posts.extend(page)
+        if len(page) < PAGE_SIZE:
+            return posts
+        offset += PAGE_SIZE
+
+
+def render(posts):
+    posts = sorted(posts, key=lambda post: post["post_date"], reverse=True)
+    items = []
+    for post in posts:
+        title = html.escape(post["title"] or "Untitled")
+        url = html.escape(post.get("canonical_url") or f"{PUBLICATION}/p/{post['slug']}")
+        year = post["post_date"][:4]
+        items.append(
+            f'{INDENT}<li>\n'
+            f'{INDENT}  <span class="w-date">{year}</span>\n'
+            f'{INDENT}  <a href="{url}" target="_blank">{title}</a>\n'
+            f'{INDENT}</li>'
+        )
+    return "\n".join(items)
+
+
+def main():
+    try:
+        posts = fetch_posts()
+    except (urllib.error.URLError, ValueError, KeyError, json.JSONDecodeError) as error:
+        sys.exit(f"Failed to fetch Substack archive: {error}")
+
+    if not posts:
+        sys.exit("Substack archive returned no posts; leaving index.html untouched.")
+
+    published = [post for post in posts if post.get("slug") not in EXCLUDED_SLUGS]
+    for slug in sorted(EXCLUDED_SLUGS - {post.get("slug") for post in posts}):
+        print(f"Warning: excluded slug {slug!r} matches no post in the archive.")
+
+    source = INDEX.read_text(encoding="utf-8")
+    block = f"{START}\n{render(published)}\n{INDENT}{END}"
+    updated, count = re.subn(
+        re.escape(START) + r".*?" + re.escape(END),
+        lambda _: block,
+        source,
+        flags=re.DOTALL,
+    )
+    if count != 1:
+        sys.exit(f"Expected exactly one {START}...{END} block, found {count}.")
+
+    excluded = len(posts) - len(published)
+    summary = f"{len(published)} posts, {excluded} excluded"
+    if updated == source:
+        print(f"No change ({summary}).")
+        return
+
+    INDEX.write_text(updated, encoding="utf-8")
+    print(f"Updated Writing list with {summary}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Pulls posts from [nolastan.substack.com](https://nolastan.substack.com/) into the Writing section, above the existing hand-written entries.

## Why not a client-side fetch

Substack's `/feed` and `/api/v1/archive` endpoints send **no `access-control-allow-origin` header**, so a browser `fetch` from `stanfordrosenthal.com` — the pattern the Bluesky thought bubble uses — gets blocked by CORS. The alternative was routing through a public CORS proxy, which adds a free third-party service as a hard dependency for the page to render its own content.

Instead, a scheduled workflow does the fetch and writes the posts straight into `index.html`. Trade-off: the list can be up to a day stale, in exchange for no JS, no third-party dependency, working with JS off, and posts being present in the HTML source for crawlers.

## What's here

- **`scripts/update_substack.py`** — pages through the archive API (stdlib only, no deps), renders `<li>` items in the existing `.writing-list` markup, and swaps them into `index.html` between `<!-- substack:start -->` / `<!-- substack:end -->` markers.
- **`.github/workflows/update-substack.yml`** — daily at 13:00 UTC (~6am Pacific) plus a manual **Run workflow** button. Commits only when the rendered list actually changed, so it won't churn commits. The commit to `main` triggers a Pages rebuild.
- **`index.html`** — the marker block, pre-populated by running the script locally so the section is correct at merge time rather than after the first scheduled run. Existing Medium / ReduceMail / LinkedIn entries are untouched below it.

## Failure behavior

Verified by running against a bad hostname and against a file with the end marker deleted: in both cases the script exits non-zero and leaves `index.html` byte-identical. A Substack outage, an empty archive response, or a mangled marker block cannot blank out the Writing list — the previously committed posts just stay put. Re-running with no new posts is a no-op.

## Excluding posts

`EXCLUDED_SLUGS` in the script hides individual posts by slug (the part of the URL after `/p/`). Matching on slug rather than title means an excluded post stays excluded if it's renamed later. A slug that matches nothing prints a warning instead of failing silently, so a typo can't quietly stop excluding.

`easter-420-earth-day-and-climate` ("Sunset Dunes is Open!") is excluded, leaving three posts: Know This Place (2026), Learning from the past (2025), Nature in the City (2025).

## Note for after merge

The repo's default workflow token permission is currently `read`. The workflow declares `permissions: contents: write`, which should be enough, but if the first run fails on `git push`, flip Settings → Actions → General → Workflow permissions to "Read and write."

🤖 Generated with [Claude Code](https://claude.com/claude-code)