### PR TITLE
Add Substack signup form to the Writing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,56 @@
       flex-shrink: 0;
     }
 
+    /* Substack signup */
+    .subscribe {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: baseline;
+      margin-bottom: 28px;
+    }
+
+    .subscribe input[type="email"] {
+      flex: 0 1 260px;
+      min-width: 0;
+      font-family: 'DM Mono', monospace;
+      font-size: 0.8rem;
+      font-weight: 300;
+      color: var(--ink);
+      background: none;
+      border: none;
+      border-bottom: 1px solid var(--rule);
+      padding: 6px 0;
+      transition: border-color 0.15s;
+    }
+
+    .subscribe input[type="email"]::placeholder { color: var(--ink-faint); }
+
+    .subscribe input[type="email"]:focus {
+      outline: none;
+      border-bottom-color: var(--accent);
+    }
+
+    .subscribe button {
+      font-family: 'DM Mono', monospace;
+      font-size: 0.72rem;
+      font-weight: 400;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-light);
+      background: none;
+      border: 1px solid var(--rule);
+      border-radius: 4px;
+      padding: 7px 14px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    .subscribe button:hover {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+
     /* Footer */
     footer {
       margin-top: 80px;
@@ -587,6 +637,10 @@
 
     <section>
       <p class="section-label">Writing</p>
+      <form class="subscribe" action="https://nolastan.substack.com/api/v1/free?nojs=true" method="post">
+        <input type="email" name="email" placeholder="you@example.com" aria-label="Email address" required />
+        <button type="submit">Subscribe</button>
+      </form>
       <ul class="writing-list">
         <!-- Posts below are synced from Substack by .github/workflows/update-substack.yml. Don't edit by hand. -->
         <!-- substack:start -->


### PR DESCRIPTION
## What

Adds a minimal email signup form at the top of the **Writing** section, above the post list.

## Why

The Writing section links out to Substack posts but gave visitors no way to subscribe. This puts the ask right where someone is already scanning the writing.

## How

A plain `<form method="post">` pointing at Substack's no-JS endpoint:

```html
<form class="subscribe" action="https://nolastan.substack.com/api/v1/free?nojs=true" method="post">
```

Chose this over Substack's official iframe embed — no third-party script, no iframe, no layout jank, and it picks up the site's existing `--ink` / `--accent` / `--rule` tokens and DM Mono type so it doesn't look bolted on. Submitting takes the visitor to Substack's confirmation page, same as the embed does.

Styling matches existing patterns: underline-only input that turns accent-orange on focus, and a bordered uppercase button reusing the same hover treatment as the section's links.

## Notes for review

- The email input is `flex: 0 1 260px` rather than full-width, so it reads as a compact control instead of stretching the whole 640px column. It shrinks (rather than wrapping the button to its own line) on narrow screens.
- Input has `required` and an `aria-label`.
- No changes to the Substack sync workflow or the `substack:start`/`end` markers — the form sits above that block.
- Verified layout via DOM geometry in a local browser; worth clicking through an actual submit before merge to confirm the Substack redirect behaves as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)